### PR TITLE
Ignore file or folder

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,10 @@ struct Args {
     /// Disable colored output
     #[arg(long, action = ArgAction::SetTrue)]
     no_color: bool,
+
+    /// Ignore a file or folder by name when calculating sizes. Repeat to ignore multiple names.
+    #[arg(long, short = 'i', value_name = "NAME", action = ArgAction::Append)]
+    ignore: Vec<String>,
 }
 
 /// Run the CLI
@@ -80,7 +84,10 @@ pub fn run() {
                 continue;
             }
             stop_spinner(&mut sp);
-            print!("{}", tree::generate_tree(path, cli.depth, cli.ascii));
+            print!(
+                "{}",
+                tree::generate_tree(path, cli.depth, cli.ascii, &cli.ignore)
+            );
         }
         return;
     }
@@ -106,6 +113,11 @@ pub fn run() {
                 Ok(metadata) => {
                     let file_size = metadata.len();
                     if let Some(file_name) = path.file_name() {
+                        if let Some(name_str) = file_name.to_str()
+                            && utils::is_ignored(name_str, &cli.ignore)
+                        {
+                            continue;
+                        }
                         let file_name = utils::truncate_filename(Path::new(file_name));
                         sizes.push(utils::Sizes {
                             name: file_name.to_string(),
@@ -124,6 +136,9 @@ pub fn run() {
             for entry in entries.flatten() {
                 let entry_path = entry.path();
                 if let Some(file_name) = entry_path.file_name().and_then(|n| n.to_str()) {
+                    if utils::is_ignored(file_name, &cli.ignore) {
+                        continue;
+                    }
                     let file_name = utils::truncate_filename(Path::new(file_name));
                     match entry.file_type() {
                         Ok(file_type) => {
@@ -136,7 +151,8 @@ pub fn run() {
                                     });
                                 }
                             } else if file_type.is_dir() {
-                                let dir_size = utils::calculate_dir_size(&entry_path);
+                                let dir_size =
+                                    utils::calculate_dir_size_with_ignore(&entry_path, &cli.ignore);
                                 sizes.push(utils::Sizes {
                                     name: file_name.to_string(),
                                     size: dir_size,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -30,6 +30,7 @@ fn collect_entries(
     base_path: &Path,
     depth: usize,
     max_depth: usize,
+    ignore: &[String],
 ) -> (Vec<Entry>, u64) {
     if depth > max_depth {
         return (vec![], 0);
@@ -54,6 +55,12 @@ fn collect_entries(
                 return (vec![], 0);
             }
 
+            if let Some(name) = entry.file_name().to_str()
+                && utils::is_ignored(name, ignore)
+            {
+                return (vec![], 0);
+            }
+
             let entry_path = entry.path();
             let relative_path = entry_path
                 .strip_prefix(base_path)
@@ -68,13 +75,13 @@ fn collect_entries(
                 if depth < max_depth {
                     // Recurse: collect children and derive size from them
                     let (sub_entries, dir_size) =
-                        collect_entries(&entry_path, base_path, depth + 1, max_depth);
+                        collect_entries(&entry_path, base_path, depth + 1, max_depth, ignore);
                     let mut entries = vec![(relative_path, dir_size, true)];
                     entries.extend(sub_entries);
                     (entries, dir_size)
                 } else {
                     // At max depth: compute size without expanding children
-                    let dir_size = utils::calculate_dir_size(&entry_path);
+                    let dir_size = utils::calculate_dir_size_with_ignore(&entry_path, ignore);
                     (vec![(relative_path, dir_size, true)], dir_size)
                 }
             } else {
@@ -177,13 +184,14 @@ fn render_tree(node: &TreeNode, prefix: &str, ascii: bool) -> String {
 /// * `path` - The path to generate tree for.
 /// * `depth` - An optional depth limit for the tree representation.
 /// * `ascii` - Whether to use ASCII characters instead of Unicode.
+/// * `ignore` - File/directory names to omit from the tree.
 ///
 /// # Returns
 ///
 /// * A String representing the tree structure.
-pub fn generate_tree(path: &Path, depth: Option<usize>, ascii: bool) -> String {
+pub fn generate_tree(path: &Path, depth: Option<usize>, ascii: bool, ignore: &[String]) -> String {
     let max_depth = depth.unwrap_or(usize::MAX);
-    let (entries, _) = collect_entries(path, path, 1, max_depth);
+    let (entries, _) = collect_entries(path, path, 1, max_depth, ignore);
     let tree = build_tree(&entries);
     render_tree(&tree, "", ascii)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,11 +15,36 @@ pub struct Sizes {
     pub is_dir: bool,
 }
 
-/// Calculate directory size in parallel, skipping symlinks
+/// Returns true if `name` matches any of the provided ignore patterns.
+///
+/// Matching is plain basename equality — a pattern like `node_modules`
+/// will match any file or directory whose name is `node_modules`.
+///
+/// # Examples
+///
+/// ```
+/// let patterns = vec!["target".to_string(), ".git".to_string()];
+/// assert!(fs_rs::utils::is_ignored("target", &patterns));
+/// assert!(!fs_rs::utils::is_ignored("src", &patterns));
+/// ```
+pub fn is_ignored(name: &str, ignore: &[String]) -> bool {
+    ignore.iter().any(|p| p == name)
+}
+
+/// Calculate directory size in parallel, skipping symlinks.
+///
+/// Equivalent to [`calculate_dir_size_with_ignore`] with an empty ignore list.
+pub fn calculate_dir_size(dir_path: &Path) -> u64 {
+    calculate_dir_size_with_ignore(dir_path, &[])
+}
+
+/// Calculate directory size in parallel, skipping symlinks and any entry
+/// whose basename matches one of the `ignore` patterns.
 ///
 /// # Arguments
 ///
 /// * `dir_path`: Path to the directory
+/// * `ignore`: List of file/directory names to skip
 ///
 /// returns: u64 - The size of the directory in bytes
 ///
@@ -28,9 +53,10 @@ pub struct Sizes {
 /// ```
 /// use std::path::Path;
 /// let dir_path = Path::new("/some/directory");
-/// let size = fs_rs::utils::calculate_dir_size(dir_path);
+/// let ignore = vec!["node_modules".to_string()];
+/// let size = fs_rs::utils::calculate_dir_size_with_ignore(dir_path, &ignore);
 /// ```
-pub fn calculate_dir_size(dir_path: &Path) -> u64 {
+pub fn calculate_dir_size_with_ignore(dir_path: &Path, ignore: &[String]) -> u64 {
     fs::read_dir(dir_path)
         .map(|entries| {
             entries
@@ -44,8 +70,13 @@ pub fn calculate_dir_size(dir_path: &Path) -> u64 {
                     if file_type.is_symlink() {
                         return 0;
                     }
+                    if let Some(name) = entry.file_name().to_str()
+                        && is_ignored(name, ignore)
+                    {
+                        return 0;
+                    }
                     if file_type.is_dir() {
-                        calculate_dir_size(&entry.path())
+                        calculate_dir_size_with_ignore(&entry.path(), ignore)
                     } else {
                         entry.metadata().map(|m| m.len()).unwrap_or(0)
                     }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -11,16 +11,9 @@ fn fs_rs() -> Command {
 fn test_default_output_contains_filename_and_total() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("test.txt");
-    File::create(&file)
-        .unwrap()
-        .write_all(b"hello")
-        .unwrap();
+    File::create(&file).unwrap().write_all(b"hello").unwrap();
 
-    let output = fs_rs()
-        .arg(dir.path())
-        .arg("--no-color")
-        .output()
-        .unwrap();
+    let output = fs_rs().arg(dir.path()).arg("--no-color").output().unwrap();
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -126,11 +119,7 @@ fn test_nonexistent_path_shows_error() {
 
 #[test]
 fn test_tree_conflicts_with_json() {
-    let output = fs_rs()
-        .arg("--tree")
-        .arg("--json")
-        .output()
-        .unwrap();
+    let output = fs_rs().arg("--tree").arg("--json").output().unwrap();
 
     assert!(
         !output.status.success(),
@@ -150,6 +139,89 @@ fn test_tree_conflicts_with_sort_by_size() {
         !output.status.success(),
         "--tree and --sort-by-size should conflict"
     );
+}
+
+#[test]
+fn test_ignore_excludes_named_entries() {
+    let dir = tempdir().unwrap();
+    let kept = dir.path().join("kept.txt");
+    let skipped = dir.path().join("skipme.txt");
+    File::create(&kept).unwrap().write_all(b"k").unwrap();
+    File::create(&skipped).unwrap().write_all(b"s").unwrap();
+
+    let output = fs_rs()
+        .arg(dir.path())
+        .arg("--ignore")
+        .arg("skipme.txt")
+        .arg("--no-color")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("kept.txt"));
+    assert!(!stdout.contains("skipme.txt"));
+}
+
+#[test]
+fn test_ignore_excludes_subdir_from_size() {
+    let dir = tempdir().unwrap();
+    let nested = dir.path().join("node_modules");
+    fs::create_dir(&nested).unwrap();
+    File::create(nested.join("big.bin"))
+        .unwrap()
+        .write_all(&[b'x'; 2048])
+        .unwrap();
+    File::create(dir.path().join("tiny.txt"))
+        .unwrap()
+        .write_all(b"t")
+        .unwrap();
+
+    let output = fs_rs()
+        .arg(dir.path())
+        .arg("--ignore")
+        .arg("node_modules")
+        .arg("--json")
+        .arg("--no-color")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(stdout.trim()).unwrap();
+    let names: Vec<&str> = parsed.iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"tiny.txt"));
+    assert!(!names.contains(&"node_modules"));
+}
+
+#[test]
+fn test_ignore_in_tree_mode() {
+    let dir = tempdir().unwrap();
+    let nested = dir.path().join("ignored_dir");
+    fs::create_dir(&nested).unwrap();
+    File::create(nested.join("hidden.txt"))
+        .unwrap()
+        .write_all(b"x")
+        .unwrap();
+    File::create(dir.path().join("visible.txt"))
+        .unwrap()
+        .write_all(b"y")
+        .unwrap();
+
+    let output = fs_rs()
+        .arg(dir.path())
+        .arg("--tree")
+        .arg("--ignore")
+        .arg("ignored_dir")
+        .arg("--no-color")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("visible.txt"));
+    assert!(!stdout.contains("ignored_dir"));
+    assert!(!stdout.contains("hidden.txt"));
 }
 
 #[test]

--- a/tests/tree_test.rs
+++ b/tests/tree_test.rs
@@ -25,12 +25,12 @@ fn test_generate_tree() {
     drop(file1);
     drop(file2);
 
-    let tree = generate_tree(dir.path(), None, false);
+    let tree = generate_tree(dir.path(), None, false, &[]);
 
     assert!(tree.contains("file1.txt"));
     assert!(tree.contains("file2.txt"));
 
-    let tree_ascii = generate_tree(dir.path(), None, true);
+    let tree_ascii = generate_tree(dir.path(), None, true, &[]);
 
     assert!(tree_ascii.contains("file1.txt"));
     assert!(tree_ascii.contains("file2.txt"));

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 use tempfile::tempdir;
 
-use fs_rs::utils::{Sizes, calculate_dir_size};
+use fs_rs::utils::{Sizes, calculate_dir_size, calculate_dir_size_with_ignore, is_ignored};
 
 #[test]
 fn test_calculate_dir_size() {
@@ -83,6 +83,38 @@ fn test_sort_by_name() {
 }
 
 #[test]
+fn test_is_ignored() {
+    let patterns = vec!["target".to_string(), ".git".to_string()];
+    assert!(is_ignored("target", &patterns));
+    assert!(is_ignored(".git", &patterns));
+    assert!(!is_ignored("src", &patterns));
+    assert!(!is_ignored("", &patterns));
+    assert!(!is_ignored("target", &[]));
+}
+
+#[test]
+fn test_calculate_dir_size_with_ignore_skips_subdir() {
+    let dir = tempdir().expect("Failed to create a temporary directory");
+    let keep = dir.path().join("keep.txt");
+    let mut keep_file = File::create(&keep).expect("Failed to create keep.txt");
+    writeln!(keep_file, "keep").expect("write");
+    drop(keep_file);
+
+    let ignored_dir = dir.path().join("node_modules");
+    std::fs::create_dir(&ignored_dir).expect("create ignored dir");
+    let ignored_file = ignored_dir.join("big.bin");
+    let mut big = File::create(&ignored_file).expect("create big");
+    big.write_all(&[0u8; 4096]).expect("write big");
+    drop(big);
+
+    let with_ignore = calculate_dir_size_with_ignore(dir.path(), &["node_modules".to_string()]);
+    let without_ignore = calculate_dir_size(dir.path());
+
+    assert!(without_ignore >= with_ignore + 4096);
+    assert!(with_ignore < 100, "only keep.txt should be counted");
+}
+
+#[test]
 fn test_truncate_filename() {
     let path = Path::new("this_is_a_long_filename_and_some_more_text_to_make_it_even_longer.txt");
     let truncated = fs_rs::utils::truncate_filename(path);
@@ -94,4 +126,3 @@ fn test_truncate_filename() {
         right, truncated
     );
 }
-


### PR DESCRIPTION
closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--ignore/-i` repeatable CLI option to exclude specific files and folders by name from directory size calculations. Use the flag multiple times to exclude different items from your analysis. Filtering works consistently across both default output and tree view modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akshaybabloo/fs_rs/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->