### PR TITLE
Truncate file in middle

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use std::fs;
 use std::path::Path;
 
-const MAX_FILENAME_LENGTH: usize = 25;
+const MAX_FILENAME_LENGTH: usize = 45;
 
 /// Struct to hold sizes of files/directories
 #[derive(Clone, Debug, PartialEq)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -148,11 +148,14 @@ pub fn truncate_filename(path: &Path) -> String {
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
     let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-    let truncated_stem = if stem.len() > MAX_FILENAME_LENGTH {
-        let prefix_len = MAX_FILENAME_LENGTH / 2;
-        let suffix_len = MAX_FILENAME_LENGTH - prefix_len;
-        let prefix = &stem[..prefix_len];
-        let suffix = &stem[stem.len() - suffix_len..];
+    let stem_chars: Vec<char> = stem.chars().collect();
+    let truncated_stem = if stem_chars.len() > MAX_FILENAME_LENGTH {
+        const SEP_LEN: usize = 3;
+        let available = MAX_FILENAME_LENGTH - SEP_LEN;
+        let prefix_len = available / 2;
+        let suffix_len = available - prefix_len;
+        let prefix: String = stem_chars[..prefix_len].iter().collect();
+        let suffix: String = stem_chars[stem_chars.len() - suffix_len..].iter().collect();
         format!("{}...{}", prefix, suffix)
     } else {
         stem.to_string()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -128,7 +128,8 @@ pub fn sort_by_name(sizes: &mut [Sizes]) {
     sizes.sort_by(|a, b| a.name.cmp(&b.name));
 }
 
-/// Truncate a filename to `MAX_FILENAME_LENGTH` characters
+/// Truncate a filename so the stem fits within `MAX_FILENAME_LENGTH` visible
+/// characters by removing the middle, keeping both the start and end intact.
 ///
 /// # Arguments
 ///
@@ -144,18 +145,19 @@ pub fn sort_by_name(sizes: &mut [Sizes]) {
 /// let truncated = fs_rs::utils::truncate_filename(path);
 /// ```
 pub fn truncate_filename(path: &Path) -> String {
-    // Extract the file stem (name without extension) and extension
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
     let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-    // Check if the stem length exceeds the maximum allowed length
     let truncated_stem = if stem.len() > MAX_FILENAME_LENGTH {
-        format!("{}...", &stem[..MAX_FILENAME_LENGTH])
+        let prefix_len = MAX_FILENAME_LENGTH / 2;
+        let suffix_len = MAX_FILENAME_LENGTH - prefix_len;
+        let prefix = &stem[..prefix_len];
+        let suffix = &stem[stem.len() - suffix_len..];
+        format!("{}...{}", prefix, suffix)
     } else {
         stem.to_string()
     };
 
-    // Append the extension if present
     if !extension.is_empty() {
         format!("{}.{}", truncated_stem, extension)
     } else {

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -118,7 +118,7 @@ fn test_calculate_dir_size_with_ignore_skips_subdir() {
 fn test_truncate_filename() {
     let path = Path::new("this_is_a_long_filename_and_some_more_text_to_make_it_even_longer.txt");
     let truncated = fs_rs::utils::truncate_filename(path);
-    let right = "this_is_a_long_filename_a....txt";
+    let right = "this_is_a_lo...t_even_longer.txt";
 
     assert_eq!(
         truncated, right,

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -118,7 +118,7 @@ fn test_calculate_dir_size_with_ignore_skips_subdir() {
 fn test_truncate_filename() {
     let path = Path::new("this_is_a_long_filename_and_some_more_text_to_make_it_even_longer.txt");
     let truncated = fs_rs::utils::truncate_filename(path);
-    let right = "this_is_a_lo...t_even_longer.txt";
+    let right = "this_is_a_long_filenam..._to_make_it_even_longer.txt";
 
     assert_eq!(
         truncated, right,

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -126,3 +126,62 @@ fn test_truncate_filename() {
         right, truncated
     );
 }
+
+#[test]
+fn test_truncate_filename_short() {
+    let path = Path::new("short.txt");
+    assert_eq!(fs_rs::utils::truncate_filename(path), "short.txt");
+}
+
+#[test]
+fn test_truncate_filename_no_extension() {
+    // Short, no extension: returned verbatim.
+    let path = Path::new("just_a_filename");
+    assert_eq!(fs_rs::utils::truncate_filename(path), "just_a_filename");
+
+    // Long, no extension: stem still truncated, no trailing dot.
+    let long = "a".repeat(60);
+    let truncated = fs_rs::utils::truncate_filename(Path::new(&long));
+    // 21 + "..." + 21 = 45 visible chars, with exactly 3 dots from the separator.
+    assert_eq!(truncated.chars().count(), 45);
+    assert_eq!(truncated.matches('.').count(), 3);
+    assert_eq!(truncated, format!("{}...{}", "a".repeat(21), "a".repeat(21)));
+}
+
+#[test]
+fn test_truncate_filename_exact_boundary() {
+    // Stem exactly MAX_FILENAME_LENGTH (45) chars — must NOT be truncated.
+    let stem = "a".repeat(45);
+    let name = format!("{}.txt", stem);
+    let truncated = fs_rs::utils::truncate_filename(Path::new(&name));
+    assert_eq!(truncated, name);
+    assert!(!truncated.contains("..."));
+}
+
+#[test]
+fn test_truncate_filename_utf8() {
+    // CJK: each `日` is 3 bytes; 50 chars × 3 = 150 bytes. Byte-slicing
+    // would have panicked on a non-boundary index; char-slicing must not.
+    let cjk = "日".repeat(50);
+    let name = format!("{}.txt", cjk);
+    let truncated = fs_rs::utils::truncate_filename(Path::new(&name));
+    let expected_stem = format!("{}...{}", "日".repeat(21), "日".repeat(21));
+    assert_eq!(truncated, format!("{}.txt", expected_stem));
+    assert_eq!(truncated.chars().count(), 45 + 4); // stem + ".txt"
+
+    // Emoji: 4 bytes per char.
+    let emoji = "😀".repeat(50);
+    let name2 = format!("{}.png", emoji);
+    let truncated2 = fs_rs::utils::truncate_filename(Path::new(&name2));
+    let expected2 = format!("{}...{}", "😀".repeat(21), "😀".repeat(21));
+    assert_eq!(truncated2, format!("{}.png", expected2));
+    assert_eq!(truncated2.chars().count(), 45 + 4);
+
+    // Accented (precomposed NFC é = 2 bytes).
+    let acc = "é".repeat(50);
+    let name3 = format!("{}.md", acc);
+    let truncated3 = fs_rs::utils::truncate_filename(Path::new(&name3));
+    let expected3 = format!("{}...{}", "é".repeat(21), "é".repeat(21));
+    assert_eq!(truncated3, format!("{}.md", expected3));
+    assert_eq!(truncated3.chars().count(), 45 + 3);
+}

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -118,7 +118,7 @@ fn test_calculate_dir_size_with_ignore_skips_subdir() {
 fn test_truncate_filename() {
     let path = Path::new("this_is_a_long_filename_and_some_more_text_to_make_it_even_longer.txt");
     let truncated = fs_rs::utils::truncate_filename(path);
-    let right = "this_is_a_long_filenam..._to_make_it_even_longer.txt";
+    let right = "this_is_a_long_filena...o_make_it_even_longer.txt";
 
     assert_eq!(
         truncated, right,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename truncation: longer names now retain more characters before truncation, preserve both start and end with an ellipsis in the middle (start...end), and keep the original file extension intact for clearer identification. Test expectations updated to reflect the new truncation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akshaybabloo/fs_rs/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->