### PR TITLE
Show only files or folder based on flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -225,9 +225,16 @@ pub fn run() {
     let total_size = sizes.iter().map(|s| s.size).sum::<u64>();
     let sz = format_size(total_size, DECIMAL);
     println!("\n{} {}", "Total size:".green(), sz.green().bold());
+    let count_label = if cli.by_folder {
+        "Number of folders:"
+    } else if cli.by_files {
+        "Number of files:"
+    } else {
+        "Number of entries:"
+    };
     println!(
         "{} {}\n",
-        "Number of files:".green(),
+        count_label.green(),
         sizes.len().to_string().green().bold()
     );
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,8 +33,16 @@ struct Args {
     json: bool,
 
     /// Show tree representation
-    #[arg(long, short, action = ArgAction::SetTrue, conflicts_with_all = ["sort_by_size", "disk_usage", "json"])]
+    #[arg(long, short, action = ArgAction::SetTrue, conflicts_with_all = ["sort_by_size", "disk_usage", "json", "by_files", "by_folder"])]
     tree: bool,
+
+    /// Show only files (omit directories from the listing)
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "by_folder")]
+    by_files: bool,
+
+    /// Show only folders (omit files from the listing)
+    #[arg(long, action = ArgAction::SetTrue)]
+    by_folder: bool,
 
     /// Depth of the tree representation. Only applicable if --tree is set. Defaults to unlimited depth.
     #[arg(long, short, action = ArgAction::Set, requires = "tree")]
@@ -165,6 +173,12 @@ pub fn run() {
                 }
             }
         }
+    }
+
+    if cli.by_files {
+        sizes.retain(|s| !s.is_dir);
+    } else if cli.by_folder {
+        sizes.retain(|s| s.is_dir);
     }
 
     if sizes.is_empty() {

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -20,8 +20,8 @@ fn test_default_output_contains_filename_and_total() {
     assert!(stdout.contains("test.txt"), "should list the file");
     assert!(stdout.contains("Total size:"), "should show total");
     assert!(
-        stdout.contains("Number of files:"),
-        "should show file count"
+        stdout.contains("Number of entries:"),
+        "should show entry count"
     );
 }
 
@@ -293,6 +293,15 @@ fn test_by_files_conflicts_with_tree() {
     assert!(
         !output.status.success(),
         "--tree and --by-files should conflict"
+    );
+}
+
+#[test]
+fn test_by_folder_conflicts_with_tree() {
+    let output = fs_rs().arg("--tree").arg("--by-folder").output().unwrap();
+    assert!(
+        !output.status.success(),
+        "--tree and --by-folder should conflict"
     );
 }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -225,6 +225,78 @@ fn test_ignore_in_tree_mode() {
 }
 
 #[test]
+fn test_by_files_excludes_folders() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("subdir")).unwrap();
+    File::create(dir.path().join("file.txt"))
+        .unwrap()
+        .write_all(b"hi")
+        .unwrap();
+
+    let output = fs_rs()
+        .arg(dir.path())
+        .arg("--by-files")
+        .arg("--json")
+        .arg("--no-color")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0]["name"], "file.txt");
+    assert_eq!(parsed[0]["is_dir"], false);
+}
+
+#[test]
+fn test_by_folder_excludes_files() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("subdir")).unwrap();
+    File::create(dir.path().join("file.txt"))
+        .unwrap()
+        .write_all(b"hi")
+        .unwrap();
+
+    let output = fs_rs()
+        .arg(dir.path())
+        .arg("--by-folder")
+        .arg("--json")
+        .arg("--no-color")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0]["name"], "subdir");
+    assert_eq!(parsed[0]["is_dir"], true);
+}
+
+#[test]
+fn test_by_files_and_by_folder_conflict() {
+    let output = fs_rs()
+        .arg("--by-files")
+        .arg("--by-folder")
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "--by-files and --by-folder should conflict"
+    );
+}
+
+#[test]
+fn test_by_files_conflicts_with_tree() {
+    let output = fs_rs().arg("--tree").arg("--by-files").output().unwrap();
+    assert!(
+        !output.status.success(),
+        "--tree and --by-files should conflict"
+    );
+}
+
+#[test]
 fn test_json_respects_sort_by_size() {
     let dir = tempdir().unwrap();
     let small = dir.path().join("small.txt");


### PR DESCRIPTION
closes #16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --by_files and --by_folder flags to show only files or only directories; they are mutually exclusive and each conflicts with --tree.
  * Non-JSON/table outputs now update the “Number of …” label to reflect files, folders, or entries as appropriate.

* **Tests**
  * Added integration tests verifying filtering and option-conflict behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akshaybabloo/fs_rs/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->